### PR TITLE
(fix) (goodbyedpi) Hard coded version number preventing unzip

### DIFF
--- a/goodbyedpi/update.ps1
+++ b/goodbyedpi/update.ps1
@@ -5,7 +5,7 @@ function global:au_SearchReplace {
         ".\tools\chocolateyInstall.ps1" = @{
             "(?i)(^\s*url\s*=\s*)('.*')"        = "`$1'$($Latest.URL32)'"
             "(?i)(^\s*checksum\s*=\s*)('.*')"   = "`$1'$($Latest.Checksum32)'"
-	    "(?i)(^\s*SpecificFolder\s*=\s*`"goodbyedpi-)(.*)(\/x86\$subfolder`")" = "`$1`"$($Latest.Version)`"`$2"
+	    "(?i)(^\s*SpecificFolder\s*=\s*`"goodbyedpi-)(.*)(\/x86\$subfolder`")" = "`$1`"$($Latest.Version)`"`$3"
         }
     }
 }

--- a/goodbyedpi/update.ps1
+++ b/goodbyedpi/update.ps1
@@ -5,6 +5,7 @@ function global:au_SearchReplace {
         ".\tools\chocolateyInstall.ps1" = @{
             "(?i)(^\s*url\s*=\s*)('.*')"        = "`$1'$($Latest.URL32)'"
             "(?i)(^\s*checksum\s*=\s*)('.*')"   = "`$1'$($Latest.Checksum32)'"
+	    "(?i)(^\s*SpecificFolder\s*=\s*`"goodbyedpi-)(.*)(\/x86\$subfolder`")" = "`$1`"$($Latest.Version)`"`$2"
         }
     }
 }


### PR DESCRIPTION
There is a hardcoded version number in the `SpecificFolder` option being provided to `Install-ChocolateyZipPackage`, which means that any newer package versions beyond version 0.1.4 haven't actually worked correctly.

This change adds a search/replace to the packages `update.ps1` which will update this version number.