### PR TITLE
Fix latest install broken URL.

### DIFF
--- a/squid/update.ps1
+++ b/squid/update.ps1
@@ -13,7 +13,7 @@ function global:au_GetLatest {
     $version = (curl -UseBasicParsing "https://api.github.com/repos/diladele/squid-windows/tags?client_id=$env:GITHUB_CLIENT_ID&client_secret=$env:GITHUB_CLIENT_SECRET" | ConvertFrom-Json).name[0] -replace '^1.',''
 	
 	@{
-        URL32   = "http://packages.diladele.com/squid/$version/squid.msi"
+        URL32   = "https://www.diladele.com/pkg/squid/$version/squid.msi"
         Version = $version
     }
 }


### PR DESCRIPTION
The current URL is http://packages.diladele.com/squid/4.14/squid.msi where packages.diladele.com is not resolved any more. Two new URLs are OK for the moment:
- <https://www.diladele.com/pkg/squid/4.14/squid.msi>
- <https://www.diladele.com/pkg/squid/3.5.28/squid.msi>